### PR TITLE
Fixes Deprecation warning for #has_rdoc (Rubygems)

### DIFF
--- a/dnsruby.gemspec
+++ b/dnsruby.gemspec
@@ -23,7 +23,6 @@ DNSSEC NSEC3 support.'
   For general discussion (please tell us how you use dnsruby): https://groups.google.com/forum/#!forum/dnsruby"
 
   s.test_file = "test/ts_offline.rb"
-  s.has_rdoc = true
   s.extra_rdoc_files = ["DNSSEC", "EXAMPLES", "README.md", "EVENTMACHINE"]
 
   unless /java/ === RUBY_PLATFORM


### PR DESCRIPTION
*** What type of change is this?

- Bugfix

*** Why is this change necessary?

- To fix the deprecation warning that happens specifically when the
dependence is fetched throught git.

*** How does it address the issue?

- Removing the offensive clause `has_rdoc` from gempspec file.

*** What side effects does this change have?

- None